### PR TITLE
Fix CmdRunDecorator.decorate method to preserve the order of evaluation for modifiers and processors

### DIFF
--- a/src/marsh/core/cmd_run_decorator.py
+++ b/src/marsh/core/cmd_run_decorator.py
@@ -208,21 +208,25 @@ class CmdRunDecorator:
         Returns:
             Callable[[bytes, bytes], tuple[bytes, bytes]]: The decorated command runner function.
         """
-        # Apply pre-modifiers (before the command runner)
-        for pre_modifier in reversed(self._pre_modifiers):  # Reverse order for before-modifiers
-            cmd_runner = pre_modifier(cmd_runner)
-
+        # 2nd
         # Apply pre-processors (before the command runner)
         for pre_processor in reversed(self._pre_processors):  # Reverse order for before-processors
             cmd_runner = pre_processor(cmd_runner)
 
+        # 1st
+        # Apply pre-modifiers (before the command runner)
+        for pre_modifier in reversed(self._pre_modifiers):  # Reverse order for before-modifiers
+            cmd_runner = pre_modifier(cmd_runner)
+
         # # Wrap the command runner
         # cmd_runner = self._apply_cmd_runner(cmd_runner)
 
+        # 3rd
         # Apply post-modifiers (after the command runner)
         for post_modifier in self._post_modifiers:
             cmd_runner = post_modifier(cmd_runner)
 
+        # 4th
         # Apply post-processors (after the command runner)
         for post_processor in self._post_processors:
             cmd_runner = post_processor(cmd_runner)

--- a/tests/core/test_cmd_run_decorator.py
+++ b/tests/core/test_cmd_run_decorator.py
@@ -305,6 +305,6 @@ def test_add_processors_and_modifiers_with_multiple_processors_and_modifiers_in_
 
     stdout, stderr = cmd_runner(b"stdout", b"stderr")
 
-    assert execution_order == ["proc1", "mod2", "proc2", "mod1"]
+    assert execution_order == ["mod2", "proc1", "mod1", "proc2"]
     assert stdout == b"stdout1"
     assert stderr == b"stderr2"


### PR DESCRIPTION
## Description
Fix `CmdRunDecorator.decorate()` method to preserve the order of evaluation for modifiers and processors.

The order should be:
1. Pre-Modifiers
2. Pre-Processors
3. Post-Modifiers
4. Post-Processors

## What kind of changes did you make?
- [ ] Add new feature or enhancement (core or non-core components)?
- [ ] Add or update extensions (non-core components)?
- [X] Refactor or optimize code?
- [X] Fix a bug?
- [ ] Add or update the documentations?
- [X] Add or update the tests?

## Checklist
- [X] This PR represents my original work and does not include plagiarized code.
- [X] I have read and adhered to the project’s CONTRIBUTING guidelines.
- [X] I have followed the project's coding style and guidelines.
- [X] Documentation has been updated to reflect changes (e.g., README, inline comments, etc.).
- [X] Related API documentation, if any, has been updated.
- [X] My code is self-documented with clear comments for complex areas.
- [X] Public methods and classes include appropriate docstrings.
- [X] Function names, variables, and class names are descriptive and adhere to naming conventions.
- [X] I understand that pull requests will not be merged if they do not pass the automated tests.
- [X] New functionality is covered by automated tests.
- [X] Code changes have been tested across relevant environments or configurations.
- [X] I have verified that the changes do not introduce any new vulnerabilities or security risks.
