### PR TITLE
Add DAG Subpackage

### DIFF
--- a/samples/dag_sample.py
+++ b/samples/dag_sample.py
@@ -1,0 +1,81 @@
+import time
+import random
+from pprint import pprint
+
+from marsh import Conveyor
+from marsh.dag import Node, SyncDag, AsyncDag, ThreadPoolDag, ThreadDag, MultiprocessDag, ProcessPoolDag
+
+
+def mock_cmd_runner(x_stdout, x_stderr, name, sleep_for=0.001):
+    time.sleep(sleep_for)
+    return f"{name}-stdout".encode(), x_stderr
+
+
+if __name__ == "__main__":
+    node_a = Node("A", Conveyor().add_cmd_runner(mock_cmd_runner, "A"))
+    node_b = Node("B", Conveyor().add_cmd_runner(mock_cmd_runner, "B"))
+    node_c = Node("C", Conveyor().add_cmd_runner(mock_cmd_runner, "C"))
+    node_d = Node("D", Conveyor().add_cmd_runner(mock_cmd_runner, "D", sleep_for=3))  # Simulate Blocking
+    node_e = Node("E", Conveyor().add_cmd_runner(mock_cmd_runner, "E"))
+    node_f = Node("F", Conveyor().add_cmd_runner(mock_cmd_runner, "F"))
+    node_g = Node("G", Conveyor().add_cmd_runner(mock_cmd_runner, "G", sleep_for=0.5))
+
+    sync_dag_1 = SyncDag("SyncDag-1")
+    sync_dag_1.do(node_a).then(node_b, node_c)
+
+    sync_dag_2 = SyncDag("SyncDag-2")
+    sync_dag_2.do(node_e).then(node_f)
+
+    async_dag_1 = AsyncDag("AsyncDag-1", max_coroutines=30, timeout=4)
+    async_dag_1.do(node_a).then(node_c, node_d, node_f, node_g)
+    async_dag_1.do(node_b).then(node_d, node_e)
+    async_dag_1.do(node_c).then(node_g)
+    async_dag_1.do(node_d).then(node_f)
+    async_dag_1.do(node_e).then(node_g)
+    async_dag_1.do(node_f).then(sync_dag_2)
+    # results = async_dag_1.start()
+    # assert len(results) == 8
+
+    thread_pool_dag_1 = ThreadPoolDag("ThreadPoolDag-1", max_workers=4)
+    thread_pool_dag_1.do(node_a).then(node_c, node_d, node_f, node_g)
+    thread_pool_dag_1.do(node_b).then(node_d, node_e)
+    thread_pool_dag_1.do(node_c).then(node_g)
+    thread_pool_dag_1.do(node_d).then(node_f)
+    thread_pool_dag_1.do(node_e).then(node_g)
+    # results = thread_pool_dag_1.start()
+    # assert len(results) == 7
+
+    thread_dag_1 = ThreadDag("ThreadDag-1", max_workers=6)
+    thread_dag_1.do(node_a).then(node_c, node_d, node_f, node_g)
+    thread_dag_1.do(node_b).then(node_d, node_e)
+    thread_dag_1.do(node_c).then(node_g)
+    thread_dag_1.do(node_d).then(node_f)
+    thread_dag_1.do(node_e).then(node_g)
+    # results = thread_dag_1.start()
+    # assert len(results) == 7
+
+    sync_dag_3 = SyncDag("SyncDag-3")
+    sync_dag_3.do(sync_dag_1).then(sync_dag_2, thread_pool_dag_1)
+    sync_dag_3.do(async_dag_1).when(sync_dag_2)
+    # results = sync_dag_3.start()
+    
+    multiprocess_dag_1 = MultiprocessDag("MultiprocessDag-1", max_processes=4)
+    multiprocess_dag_1.do(node_a).then(node_c, node_d, node_f, node_g)
+    multiprocess_dag_1.do(node_b).then(node_d, node_e)
+    multiprocess_dag_1.do(node_c).then(node_g)
+    multiprocess_dag_1.do(node_d).then(node_f)
+    multiprocess_dag_1.do(node_e).then(node_g)
+    # results = multiprocess_dag_1.start()
+    # assert len(results) == 7
+
+    process_pool_dag_1 = ProcessPoolDag("ProcessPoolDag-1", max_processes=4)
+    process_pool_dag_1.do(node_a).then(node_c, node_d, node_f, node_g)
+    process_pool_dag_1.do(node_b).then(node_d, node_e)
+    process_pool_dag_1.do(node_c).then(node_g)
+    process_pool_dag_1.do(node_d).then(node_f)
+    process_pool_dag_1.do(node_e).then(node_g)
+    print(process_pool_dag_1.graph)
+    results = process_pool_dag_1.start()
+    assert len(results) == 7
+
+    pprint(results, indent=4, width=60, depth=20)

--- a/src/marsh/core/dag/__init__.py
+++ b/src/marsh/core/dag/__init__.py
@@ -1,3 +1,0 @@
-"""
-This subpackage contains the core components for building a concurrent Directed Acyclic Graph (DAG).
-"""

--- a/src/marsh/dag/__init__.py
+++ b/src/marsh/dag/__init__.py
@@ -1,0 +1,11 @@
+from .startable import Startable
+from .node import Node
+from .dag import (
+    Dag,
+    SyncDag,
+    AsyncDag,
+    ThreadPoolDag,
+    ThreadDag,
+    MultiprocessDag,
+    ProcessPoolDag
+)

--- a/src/marsh/dag/dag.py
+++ b/src/marsh/dag/dag.py
@@ -1,0 +1,398 @@
+import asyncio
+import threading
+import multiprocessing
+from concurrent.futures import as_completed, Future, ThreadPoolExecutor, ProcessPoolExecutor
+from graphlib import TopologicalSorter
+from typing import Dict, Optional, Set, List, Tuple, Self, Any
+
+from .startable import Startable
+
+
+class Dag(Startable):
+    def __init__(self, name):
+        super().__init__(name)
+        self._startables: Dict[str, Startable] = {}
+        self._graph: Dict[str, Set[str]] = {}
+        self._sorter: Optional[TopologicalSorter] = None
+        self._last_startable: Optional[List[Startable]] = []
+
+    @property
+    def startables(self) -> List[Startable]:
+        return list(self._startables.values())
+
+    @property
+    def names(self) -> List[str]:
+        return list(self._startables.keys())
+
+    @property
+    def sorted_names(self) -> List[str]:
+        sorter = self.sorter
+        if sorter is None: return []
+        return list(sorter.static_order())
+
+    @property
+    def sorter(self) -> Optional[TopologicalSorter]:
+        return TopologicalSorter(graph=self._graph) if self._graph else None
+
+    @property
+    def graph(self) -> Dict[str, Set[str]]:
+        return self._graph
+
+    def reset(self) -> None:
+        self._startables.clear()
+        self._sorter = TopologicalSorter()
+        self._graph.clear()
+        self._last_startable = []
+
+    def add(self, dependent: Startable, *dependencies: Startable) -> Self:
+        """Adds a startable and its dependencies to the DAG."""
+        # Update the Startable Dictionary
+        self._startables[dependent.name] = dependent
+
+        for dependency in dependencies:
+            self._startables[dependency.name] = dependency
+
+        # # Update the Graph Dictionary
+        # dependency_set: set[str] = self._graph.get(dependent.name, set())
+        # self._graph[dependent.name] = dependency_set | set([dependency.name for dependency in dependencies])
+        self._graph.setdefault(dependent.name, set()).update([d.name for d in dependencies])
+
+        return self
+
+    def remove(self, startable: Startable) -> None:
+        try:
+            del self._startables[startable.name]
+        except KeyError:
+            pass
+        
+        # Remove the startable from Graph Dictionary
+        try:
+            del self._graph[startable.name]
+        except KeyError:
+            pass
+        
+        # Remove the startable from some dependency set of other startable in graph dictionary
+        for name, dependency_set in self._graph.items():
+            if startable.name in dependency_set:
+                self._graph[name].remove(startable.name)
+
+    def do(self, *startables: Startable) -> Self:
+        for startable in startables:
+            self.add(startable)
+
+        self._last_startable = startables
+        return self
+
+    def then(self, *dependents: Startable) -> Self:
+        assert dependents, "Dependents cannot be empty."
+
+        for dependent in dependents:
+            self.add(dependent, *self._last_startable)
+
+        self._last_startable = dependents  # Updated to avoid side effects
+        return self
+
+    def when(self, *dependencies: Startable) -> Self:
+        assert dependencies, "Dependencies cannot be empty."
+
+        for dependent in self._last_startable:
+            self.add(dependent, *dependencies)
+
+        return self
+
+    def start(self) -> Dict[str, Tuple[bytes, bytes] | dict]:
+        raise NotImplementedError("Add implementation to Dag.start")
+
+
+class SyncDag(Dag):
+    def start(self) -> Dict[str, Any]:
+        results = {}
+        for name in self.sorted_names:
+            startable = self._startables[name]
+            result = startable.start()
+            results[startable.name] = result
+
+        return results
+
+
+class AsyncDag(Dag):
+    def __init__(self, name: str, max_coroutines: int = 20, timeout: float = 600):
+        super().__init__(name)
+        self._max_coroutines = max_coroutines
+        self._timeout = timeout
+
+    async def _worker(self,
+                      sorter: TopologicalSorter,
+                      startable: Startable,
+                      semaphore: asyncio.Semaphore,
+                      lock: asyncio.Lock,
+                      ) -> Dict[str, Any] | Tuple[bytes, bytes]:
+        async with semaphore:
+            try:
+                result = await asyncio.wait_for(asyncio.to_thread(startable.start), self._timeout)
+            except TimeoutError:
+                raise TimeoutError(f"{startable.name} exceeded {self._timeout} seconds.")
+
+            # Ensure only one task updates the TopologicalSorter at a time
+            async with lock:
+                sorter.done(startable.name)
+
+            return startable.name, result
+
+    async def _main_loop(self) -> Dict[str, Any]:
+        sorter = self.sorter
+        sorter.prepare()
+
+        semaphore = asyncio.Semaphore(self._max_coroutines)  # Limit concurrent coroutines
+        lock = asyncio.Lock()
+        tasks = []
+        results = []
+
+        while sorter.is_active():
+            ready_names = sorter.get_ready()
+            for name in ready_names:
+                startable = self._startables[name]
+                task = asyncio.create_task(self._worker(sorter, startable, semaphore, lock))
+                tasks.append(task)
+
+            # Wait for at least one task to finish before continuing
+            if tasks:
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                tasks = list(pending)  # Keep only pending tasks for the next iteration
+
+                # Collect results from completed tasks
+                for completed_task in done:
+                    result = await completed_task
+                    results.append(result)
+
+        # Ensure any remaining tasks are awaited and results collected
+        if tasks:
+            for task in tasks:
+                result = await task
+                results.append(result)
+
+        return {name: result for name, result in results}
+
+    def start(self) -> Dict[str, Any]:
+        return asyncio.run(self._main_loop())
+
+
+class ThreadPoolDag(Dag):
+    def __init__(self, name: str, max_workers: int = 6):
+        super().__init__(name)
+        self._max_workers = max_workers
+
+    def _worker(self,
+                sorter: TopologicalSorter,
+                startable: Startable,
+                lock: threading.Lock,
+                results: Dict[str, Any]
+                ) -> None:
+
+        result = startable.start()
+
+        with lock:
+            sorter.done(startable.name)
+            results[startable.name] = result
+
+    def start(self) -> Dict[str, Any]:
+        sorter = self.sorter
+        sorter.prepare()
+
+        lock = threading.Lock()
+        results = {}
+
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures: list[Future] = []
+            while sorter.is_active():
+                ready_names = []
+                with lock:
+                    ready_names = sorter.get_ready()
+
+                for name in ready_names:
+                    startable = self._startables[name]
+                    future = executor.submit(self._worker, sorter, startable, lock, results)
+                    futures.append(future)
+
+            for future in as_completed(futures):
+                future.result()
+
+        return results
+
+
+class ThreadDag(Dag):
+    def __init__(self, name: str, max_workers: int = 6):
+        super().__init__(name)
+        self._max_workers = max_workers
+
+    def _worker(self,
+                sorter: TopologicalSorter,
+                startable: Startable,
+                results: Dict[str, Any],
+                lock: threading.Lock,
+                semaphore: threading.Semaphore
+                ) -> None:
+        with semaphore:
+            result = startable.start()
+
+            with lock:
+                results[startable.name] = result
+
+            with lock:
+                sorter.done(startable.name)
+
+    def start(self) -> Dict[str, Any]:
+        sorter = self.sorter
+        sorter.prepare()
+
+        lock = threading.Lock()
+        semaphore = threading.Semaphore(self._max_workers)  # Control the Number of Threads
+
+        results: dict[str, Any] = {}
+        workers: list[threading.Thread] = []
+
+        # Start the Loop
+        while sorter.is_active():
+            ready_names = sorter.get_ready()
+            with lock:
+                if ready_names:
+                    for name in ready_names:
+                        # Dispatch a worker only if there's room in the semaphore
+                        startable = self._startables[name]
+                        thread = threading.Thread(
+                            target=self._worker,
+                            args=(sorter, startable, results, lock, semaphore),
+                            daemon=True
+                        )
+                        thread.start()
+                        workers.append(thread)
+
+        # Wait for all threads to finish
+        for thread in workers:
+            thread.join()
+
+        return results
+
+
+class MultiprocessDag(Dag):
+    def __init__(self, name: str, max_processes=4):
+        super().__init__(name)
+        self._max_processes = max_processes
+
+    @staticmethod
+    def _worker(ns, lock, startable_queue, done_queue) -> None:
+        while True:
+            if not startable_queue.empty():
+                startable = startable_queue.get()
+                result = startable.start()
+
+                with lock:
+                    ns.results[startable.name] = result
+                
+                done_queue.put(startable)
+                startable_queue.task_done()
+
+    @staticmethod
+    def _marker(sorter, lock, done_queue, stop_event) -> None:
+        while not (stop_event.is_set() and done_queue.empty() and not sorter.is_active()):
+            if not done_queue.empty():
+                startable = done_queue.get()
+                with lock:
+                    sorter.done(startable.name)
+                done_queue.task_done()
+
+    def start(self) -> Dict[str, Any]:
+        sorter = self.sorter
+        sorter.prepare()
+
+        with multiprocessing.Manager() as manager:
+            # Use Namespace to share results
+            ns = manager.Namespace()
+            ns.results = manager.dict()  # Dictionary of Results
+
+            # Mutex
+            lock = manager.Lock()
+
+            # Queues
+            startable_queue = manager.Queue()
+            done_queue = manager.Queue()
+
+            # Events
+            stop_event = manager.Event()
+
+            # Start the Worker Processes
+            workers: list[multiprocessing.Process] = []
+            for _ in range(self._max_processes):
+                process = multiprocessing.Process(
+                    target=self._worker,
+                    args=(ns, lock, startable_queue, done_queue),
+                    daemon=True
+                )
+                process.start()
+                workers.append(process)
+
+            # Start the Marker Thread
+            marker_thread = threading.Thread(
+                target=self._marker,
+                args=(sorter, lock, done_queue, stop_event),
+                daemon=True
+            )
+            marker_thread.start()
+
+            # Loop until all startables are processed and completed
+            while sorter.is_active():
+                with lock:
+                    ready_names = sorter.get_ready()
+                    if ready_names:
+                        for name in ready_names:
+                            startable = self._startables[name]
+                            startable_queue.put(startable)
+
+            # Wait until all startables are processed
+            startable_queue.join()
+
+            # Wait until all startables are marked
+            done_queue.join()
+
+            # Set the Stop Event to signal the Processes and Thread
+            stop_event.set()
+
+            # Wait until marker is done
+            marker_thread.join()
+
+            # Terminate all worker processes
+            for process in workers:
+                process.terminate()
+
+            return dict(ns.results)
+
+
+class ProcessPoolDag(Dag):
+    def __init__(self, name: str, max_processes: int = 4):
+        super().__init__(name)
+        self._max_processes = max_processes
+
+    def start(self) -> Dict[str, Any]:
+        sorter = self.sorter
+        sorter.prepare()
+
+        results = {}
+        with ProcessPoolExecutor(max_workers=self._max_processes) as pool:
+            futures: dict[Future, Startable] = {}
+
+            while sorter.is_active():
+                ready_names = sorter.get_ready()
+                for name in ready_names:
+                    startable = self._startables[name]
+                    futures[pool.submit(startable.start)] = startable
+
+                # Check completed futures without blocking others
+                completed_futures = [f for f in futures if f.done()]  # Polling
+                for future in completed_futures:
+                    startable = futures[future]
+                    result = future.result()
+                    results[startable.name] = result
+                    sorter.done(startable.name)
+                    del futures[future]
+
+        return results

--- a/src/marsh/dag/dag.py
+++ b/src/marsh/dag/dag.py
@@ -3,7 +3,7 @@ import threading
 import multiprocessing
 from concurrent.futures import as_completed, Future, ThreadPoolExecutor, ProcessPoolExecutor
 from graphlib import TopologicalSorter
-from typing import Dict, Optional, Set, List, Tuple, Self, Any
+from typing import Dict, Optional, Set, List, Tuple, Any
 
 from .startable import Startable
 
@@ -44,7 +44,7 @@ class Dag(Startable):
         self._graph.clear()
         self._last_startable = []
 
-    def add(self, dependent: Startable, *dependencies: Startable) -> Self:
+    def add(self, dependent: Startable, *dependencies: Startable) -> "Dag":
         """Adds a startable and its dependencies to the DAG."""
         # Update the Startable Dictionary
         self._startables[dependent.name] = dependent
@@ -80,14 +80,14 @@ class Dag(Startable):
             if startable.name in dependency_set:
                 self._graph[name].remove(startable.name)
 
-    def do(self, *startables: Startable) -> Self:
+    def do(self, *startables: Startable) -> "Dag":
         for startable in startables:
             self.add(startable)
 
         self._last_startable = startables
         return self
 
-    def then(self, *dependents: Startable) -> Self:
+    def then(self, *dependents: Startable) -> "Dag":
         assert dependents, "Dependents cannot be empty."
 
         for dependent in dependents:
@@ -96,7 +96,7 @@ class Dag(Startable):
         self._last_startable = dependents  # Updated to avoid side effects
         return self
 
-    def when(self, *dependencies: Startable) -> Self:
+    def when(self, *dependencies: Startable) -> "Dag":
         assert dependencies, "Dependencies cannot be empty."
 
         for dependent in self._last_startable:

--- a/src/marsh/dag/dag.py
+++ b/src/marsh/dag/dag.py
@@ -9,7 +9,35 @@ from .startable import Startable
 
 
 class Dag(Startable):
+    """
+    Base class representing a Directed Acyclic Graph (DAG) of Startable objects.
+
+    The `Dag` class manages a collection of `Startable` objects and defines their dependencies. Subclasses
+    of `Dag` implement different strategies for executing the startable objects (e.g., synchronously, asynchronously,
+    using threads or processes).
+
+    Attributes:
+        _startables (dict): A dictionary mapping startable names to `Startable` objects.
+        _graph (dict): A dictionary representing the dependency graph of startables.
+        _sorter (Optional[TopologicalSorter]): A topological sorter used to order the startables based on dependencies.
+        _last_startable (Optional[List[Startable]]): The list of the most recently added startables.
+
+    Methods:
+        add(dependent, *dependencies): Adds a dependent `Startable` and its dependencies to the DAG.
+        remove(startable): Removes a `Startable` from the DAG.
+        do(*startables): Adds the specified startables to the DAG and marks them as the last startables.
+        then(*dependents): Specifies the dependents of the last startables, adding them to the DAG.
+        when(*dependencies): Specifies the dependencies for the last startables.
+        start(): Starts the DAG execution (method to be overriden by subclasses).
+    """
+
     def __init__(self, name):
+        """
+        Initializes a DAG with the specified name.
+
+        Args:
+            name (str): The name of the DAG.
+        """
         super().__init__(name)
         self._startables: Dict[str, Startable] = {}
         self._graph: Dict[str, Set[str]] = {}
@@ -18,34 +46,86 @@ class Dag(Startable):
 
     @property
     def startables(self) -> List[Startable]:
+        """
+        Returns a list of all `Startable` objects in the DAG.
+
+        Returns:
+            List[Startable]: A list of all `Startable` objects managed by the DAG.
+        """
         return list(self._startables.values())
 
     @property
     def names(self) -> List[str]:
+        """
+        Returns a list of the names of all `Startable` objects in the DAG.
+
+        Returns:
+            List[str]: A list of names of all `Startable` objects.
+        """
         return list(self._startables.keys())
 
     @property
     def sorted_names(self) -> List[str]:
+        """
+        Returns a list of startable names in topologically sorted order.
+
+        This property depends on the dependency graph of the startables.
+
+        Returns:
+            List[str]: A list of startable names sorted by their dependencies.
+        """
         sorter = self.sorter
         if sorter is None: return []
         return list(sorter.static_order())
 
     @property
     def sorter(self) -> Optional[TopologicalSorter]:
+        """
+        Returns a TopologicalSorter instance based on the DAG's dependency graph.
+
+        This property computes a `TopologicalSorter` when the graph is not empty.
+
+        Returns:
+            Optional[TopologicalSorter]: The topological sorter instance or `None` if the graph is empty.
+        """
         return TopologicalSorter(graph=self._graph) if self._graph else None
 
     @property
     def graph(self) -> Dict[str, Set[str]]:
+        """
+        Returns the dependency graph of startables in the DAG.
+
+        The graph is represented as a dictionary, where each key is the dependent startable name, and each value
+        is a set of names of other startable dependencies of the dependent startable.
+
+        Returns:
+            Dict[str, Set[str]]: The dependency graph of startables.
+        """
         return self._graph
 
     def reset(self) -> None:
+        """
+        Resets the DAG, clearing all startables and dependencies.
+
+        This method clears the `_startables`, `_graph`, and `_last_startable` attributes.
+        It also resets the topological sorter.
+        """
         self._startables.clear()
         self._sorter = TopologicalSorter()
         self._graph.clear()
         self._last_startable = []
 
     def add(self, dependent: Startable, *dependencies: Startable) -> "Dag":
-        """Adds a startable and its dependencies to the DAG."""
+        """
+        Adds a dependent `Startable` and its dependencies to the DAG.
+
+        Args:
+            dependent (Startable): The `Startable` to be added as a dependent in the DAG.
+            *dependencies (Startable): The `Startable` objects that the dependent depends on.
+
+        Returns:
+            Dag: The updated `Dag` instance with the newly added dependent and its dependencies.
+        """
         # Update the Startable Dictionary
         self._startables[dependent.name] = dependent
 
@@ -64,23 +144,38 @@ class Dag(Startable):
         return self
 
     def remove(self, startable: Startable) -> None:
+        """
+        Removes a `Startable` from the DAG.
+
+        Args:
+            startable (Startable): The `Startable` to be removed from the DAG.
+        """
         try:
             del self._startables[startable.name]
         except KeyError:
             pass
-        
+
         # Remove the startable from Graph Dictionary
         try:
             del self._graph[startable.name]
         except KeyError:
             pass
-        
+
         # Remove the startable from some dependency set of other startable in graph dictionary
         for name, dependency_set in self._graph.items():
             if startable.name in dependency_set:
                 self._graph[name].remove(startable.name)
 
     def do(self, *startables: Startable) -> "Dag":
+        """
+        Adds the specified `Startable` objects to the DAG and marks them as the last added startables.
+
+        Args:
+            *startables (Startable): The `Startable` objects to be added to the DAG.
+
+        Returns:
+            Dag: The updated `Dag` instance with the newly added startables.
+        """
         for startable in startables:
             self.add(startable)
 
@@ -88,6 +183,15 @@ class Dag(Startable):
         return self
 
     def then(self, *dependents: Startable) -> "Dag":
+        """
+        Specifies the dependents of the last added startables, adding them to the DAG.
+
+        Args:
+            *dependents (Startable): The `Startable` objects that depend on the last added startables.
+
+        Returns:
+            Dag: The updated `Dag` instance with the newly added dependents.
+        """
         assert dependents, "Dependents cannot be empty."
 
         for dependent in dependents:
@@ -97,6 +201,15 @@ class Dag(Startable):
         return self
 
     def when(self, *dependencies: Startable) -> "Dag":
+        """
+        Specifies the dependencies for the last added startables.
+
+        Args:
+            *dependencies (Startable): The `Startable` objects that the last added startables depend on.
+
+        Returns:
+            Dag: The updated `Dag` instance with the newly added dependencies.
+        """
         assert dependencies, "Dependencies cannot be empty."
 
         for dependent in self._last_startable:
@@ -105,11 +218,37 @@ class Dag(Startable):
         return self
 
     def start(self) -> Dict[str, Tuple[bytes, bytes] | dict]:
+        """
+        Starts the DAG execution.
+
+        This method should be implemented by subclasses to define how the startables are executed.
+
+        Raises:
+            NotImplementedError: This method must be implemented by subclasses.
+        """
         raise NotImplementedError("Add implementation to Dag.start")
 
 
 class SyncDag(Dag):
+    """
+    A synchronous implementation of the `Dag` class.
+
+    The `SyncDag` class executes all startable objects in the DAG sequentially, ensuring that each startable
+    is executed only after its dependencies have been completed.
+
+    Methods:
+        start(): Executes the startables sequentially and returns the results as a dictionary.
+    """
+
     def start(self) -> Dict[str, Any]:
+        """
+       Starts the DAG execution synchronously.
+
+       Executes each startable in topologically sorted order and returns the results in a dictionary.
+
+       Returns:
+           Dict[str, Any]: A dictionary mapping startable names to their results.
+       """
         results = {}
         for name in self.sorted_names:
             startable = self._startables[name]
@@ -120,7 +259,31 @@ class SyncDag(Dag):
 
 
 class AsyncDag(Dag):
+    """
+    An asynchronous implementation of the `Dag` class using asyncio.
+
+    The `AsyncDag` class executes startable objects concurrently, using asyncio to manage coroutines and tasks
+    for parallel execution, while respecting the dependencies defined by the DAG structure.
+
+    Attributes:
+        _max_coroutines (int): The maximum number of concurrent coroutines allowed.
+        _timeout (float): The maximum time (in seconds) to wait for each startable.
+
+    Methods:
+        _worker(sorter, startable, semaphore, lock): Worker function that runs the startable asynchronously.
+        _main_loop(): Main loop that manages execution and ensures tasks are completed in dependency order.
+        start(): Starts the DAG execution asynchronously and returns the results as a dictionary.
+    """
+
     def __init__(self, name: str, max_coroutines: int = 20, timeout: float = 600):
+        """
+        Initializes a AsyncDag with the specified name, maximum number of coroutines, and timeout.
+
+        Args:
+            name (str): The name of the AsyncDag.
+            max_coroutines (int, optional): The maximum number of concurrent coroutines. Defaults to 20.
+            timeout (float, optional): The time limit (seconds) for running a startable. Defaults to 600.
+        """
         super().__init__(name)
         self._max_coroutines = max_coroutines
         self._timeout = timeout
@@ -131,6 +294,19 @@ class AsyncDag(Dag):
                       semaphore: asyncio.Semaphore,
                       lock: asyncio.Lock,
                       ) -> Dict[str, Any] | Tuple[bytes, bytes]:
+        """
+        Worker function to execute a startable asynchronously with a semaphore.
+
+        Args:
+            sorter (TopologicalSorter): The sorter to update as tasks are completed.
+            startable (Startable): The startable to execute.
+            semaphore (asyncio.Semaphore): Limits the number of concurrent coroutines.
+            lock (asyncio.Lock): Ensures thread safety when updating the sorter.
+
+        Returns:
+            Tuple[str, Any]: A tuple containing the startable name and its result.
+        """
+
         async with semaphore:
             try:
                 result = await asyncio.wait_for(asyncio.to_thread(startable.start), self._timeout)
@@ -144,6 +320,12 @@ class AsyncDag(Dag):
             return startable.name, result
 
     async def _main_loop(self) -> Dict[str, Any]:
+        """
+        Main loop to execute startables concurrently in topological order.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping startable names to their results.
+        """
         sorter = self.sorter
         sorter.prepare()
 
@@ -178,11 +360,38 @@ class AsyncDag(Dag):
         return {name: result for name, result in results}
 
     def start(self) -> Dict[str, Any]:
+        """
+        Starts the asynchronous DAG execution.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping startable names to their results.
+        """
         return asyncio.run(self._main_loop())
 
 
 class ThreadPoolDag(Dag):
+    """
+    A `Dag` implementation using a thread pool.
+
+    The `ThreadPoolDag` class executes startables concurrently using a thread pool, limiting the number of threads
+    running concurrently to the specified maximum.
+
+    Attributes:
+        _max_workers (int): The maximum number of workers in the thread pool.
+
+    Methods:
+        _worker(sorter, startable, lock, results): Worker function to execute a startable in a thread.
+        start(): Starts the DAG execution using the thread pool and returns the results as a dictionary.
+    """
+
     def __init__(self, name: str, max_workers: int = 6):
+        """
+        Initializes the thread pool DAG with the given name and maximum number of worker threads.
+
+        Args:
+            name (str): The name of the DAG.
+            max_workers (int, optional): The maximum number of worker threads. Defaults to 6.
+        """
         super().__init__(name)
         self._max_workers = max_workers
 
@@ -192,6 +401,15 @@ class ThreadPoolDag(Dag):
                 lock: threading.Lock,
                 results: Dict[str, Any]
                 ) -> None:
+        """
+        Worker function to execute a startable in a thread.
+
+        Args:
+            sorter (TopologicalSorter): The sorter to update as tasks are completed.
+            startable (Startable): The startable to execute.
+            lock (threading.Lock): Ensures thread safety when updating the sorter.
+            results (dict): A dictionary to store the results of executed startables.
+        """
 
         result = startable.start()
 
@@ -200,6 +418,12 @@ class ThreadPoolDag(Dag):
             results[startable.name] = result
 
     def start(self) -> Dict[str, Any]:
+        """
+        Starts the DAG execution using a thread pool.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping startable names to their results.
+        """
         sorter = self.sorter
         sorter.prepare()
 
@@ -226,6 +450,13 @@ class ThreadPoolDag(Dag):
 
 class ThreadDag(Dag):
     def __init__(self, name: str, max_workers: int = 6):
+        """
+        Initializes the threaded DAG with the given name and maximum number of threads.
+
+        Args:
+            name (str): The name of the DAG.
+            max_workers (int, optional): The maximum number of threads to run concurrently. Defaults to 6.
+        """
         super().__init__(name)
         self._max_workers = max_workers
 
@@ -236,6 +467,18 @@ class ThreadDag(Dag):
                 lock: threading.Lock,
                 semaphore: threading.Semaphore
                 ) -> None:
+        """
+        Worker method to execute a task in a thread and update results.
+
+        This method runs each task in a separate thread and updates the results and topological sorter.
+
+        Args:
+            sorter (TopologicalSorter): The topological sorter for the DAG.
+            startable (Startable): The task to be executed.
+            results (Dict[str, Any]): A dictionary to store task results.
+            lock (threading.Lock): Lock to ensure thread-safe updates.
+            semaphore (threading.Semaphore): Semaphore to limit the number of concurrent threads.
+        """
         with semaphore:
             result = startable.start()
 
@@ -246,6 +489,15 @@ class ThreadDag(Dag):
                 sorter.done(startable.name)
 
     def start(self) -> Dict[str, Any]:
+        """
+        Starts the execution of tasks in the DAG using threads.
+
+        This method manages the execution of tasks using threads. It controls the maximum number of concurrent threads
+        using a semaphore and collects results in a shared dictionary.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping task names to their results.
+        """
         sorter = self.sorter
         sorter.prepare()
 
@@ -279,12 +531,46 @@ class ThreadDag(Dag):
 
 
 class MultiprocessDag(Dag):
+    """
+    A Directed Acyclic Graph (DAG) that executes tasks concurrently using multiple worker processes.
+
+    This class utilizes multiple processes to execute tasks in parallel, allowing for parallel computation across
+    multiple CPU cores. Each task is processed by one of the available worker processes, while a marker thread
+    tracks completed tasks and updates the DAG sorter to ensure task dependencies are respected. Tasks are
+    submitted to a queue, executed, and results are stored in a shared namespace.
+
+    Attributes:
+        _max_processes (int): The maximum number of worker processes to use for concurrent execution. Default is 4.
+    """
+
     def __init__(self, name: str, max_processes=4):
+        """
+        Initializes the multiprocess DAG with the given name and maximum number of worker processes.
+
+        This class executes tasks concurrently using multiple processes, allowing parallel execution across different
+        CPUs.
+
+        Args:
+            name (str): The name of the DAG.
+            max_processes (int, optional): The maximum number of worker processes. Defaults to 4.
+        """
         super().__init__(name)
         self._max_processes = max_processes
 
     @staticmethod
     def _worker(ns, lock, startable_queue, done_queue) -> None:
+        """
+        Worker method that processes tasks from the startable_queue and stores results in the shared namespace.
+
+        Each worker takes tasks from the queue, processes them, and stores the result in a thread-safe dictionary.
+        Once the task is completed, it is put into the done_queue to be marked as done for sorter.
+
+        Args:
+            ns (multiprocessing.Namespace): Shared namespace to store task results.
+            lock (multiprocessing.Lock): A lock to synchronize access to the shared results.
+            startable_queue (multiprocessing.Queue): Queue of startable tasks to be processed.
+            done_queue (multiprocessing.Queue): Queue to track completed tasks.
+        """
         while True:
             if not startable_queue.empty():
                 startable = startable_queue.get()
@@ -292,12 +578,24 @@ class MultiprocessDag(Dag):
 
                 with lock:
                     ns.results[startable.name] = result
-                
+
                 done_queue.put(startable)
                 startable_queue.task_done()
 
     @staticmethod
     def _marker(sorter, lock, done_queue, stop_event) -> None:
+        """
+        Marker thread that tracks task completion and updates the sorter.
+
+        The marker thread continually monitors the done_queue for completed tasks and updates the DAG sorter
+        to mark tasks as done, ensuring the DAG is correctly processed.
+
+        Args:
+            sorter (TopologicalSorter): The sorter managing task dependencies.
+            lock (multiprocessing.Lock): A lock to synchronize access to the sorter.
+            done_queue (multiprocessing.Queue): Queue tracking tasks that have been completed.
+            stop_event (multiprocessing.Event): Event to signal when the process should stop.
+        """
         while not (stop_event.is_set() and done_queue.empty() and not sorter.is_active()):
             if not done_queue.empty():
                 startable = done_queue.get()
@@ -306,6 +604,18 @@ class MultiprocessDag(Dag):
                 done_queue.task_done()
 
     def start(self) -> Dict[str, Any]:
+        """
+        Starts the execution of tasks in the DAG using multiple processes and a marker thread.
+
+        The method prepares the DAG, starts worker processes to handle tasks in parallel, and uses a marker thread
+        to track task completion. It ensures that all tasks are processed and results are collected.
+
+        Args:
+            name (str): The name of the DAG.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping task names to their results.
+        """
         sorter = self.sorter
         sorter.prepare()
 
@@ -372,11 +682,45 @@ class MultiprocessDag(Dag):
 
 
 class ProcessPoolDag(Dag):
+    """
+    A Directed Acyclic Graph (DAG) that executes tasks concurrently using a process pool.
+
+    This class uses a `ProcessPoolExecutor` to execute tasks concurrently in a pool of worker processes. Tasks
+    are submitted to the pool and executed in parallel. The results are gathered as they complete, and the task
+    dependencies are handled by the DAG sorter to ensure tasks execute in the correct order.
+
+    Attributes:
+        _max_processes (int): The maximum number of processes to use in the pool for concurrent execution. Default is 4.
+    """
+
     def __init__(self, name: str, max_processes: int = 4):
+        """
+        Initializes the process pool DAG with the given name and maximum number of worker processes in the pool.
+
+        This class uses a process pool to execute tasks concurrently. Each task is submitted to the pool, and the results
+        are tracked as they are completed.
+
+        Args:
+            name (str): The name of the DAG.
+            max_processes (int, optional): The maximum number of processes to run concurrently in the process pool.
+                Defaults to 4.
+        """
         super().__init__(name)
         self._max_processes = max_processes
 
     def start(self) -> Dict[str, Any]:
+        """
+        Starts the execution of tasks in the DAG using a process pool.
+
+        The method submits tasks to the process pool, waits for their completion, and collects results. It ensures that
+        tasks are executed concurrently and the results are properly handled and sorted.
+
+        Args:
+            name (str): The name of the DAG.
+
+        Returns:
+            Dict[str, Any]: A dictionary mapping task names to their results.
+        """
         sorter = self.sorter
         sorter.prepare()
 

--- a/src/marsh/dag/dag.py
+++ b/src/marsh/dag/dag.py
@@ -52,7 +52,11 @@ class Dag(Startable):
         for dependency in dependencies:
             self._startables[dependency.name] = dependency
 
-        # # Update the Graph Dictionary
+            # Make sure that if the dependency is not yet registered to the graph,
+            # then add them with with default empty set for their own dependencies.
+            self._graph[dependency.name] = self._graph.get(dependency.name, set())
+
+        # Update the Graph Dictionary
         # dependency_set: set[str] = self._graph.get(dependent.name, set())
         # self._graph[dependent.name] = dependency_set | set([dependency.name for dependency in dependencies])
         self._graph.setdefault(dependent.name, set()).update([d.name for d in dependencies])

--- a/src/marsh/dag/node.py
+++ b/src/marsh/dag/node.py
@@ -5,7 +5,32 @@ from .startable import Startable
 
 
 class Node(Startable):
+    """
+    A Node represents an object that can be started, typically as part of a workflow or graph.
+
+    This class extends `Startable` and represents a node in a directed acyclic graph (DAG) or similar structure.
+    Each node is responsible for starting a process using a `Conveyor` object. The `start` method invokes the `Conveyor`
+    with the provided keyword arguments, returning the result as a 2-tuple of bytes.
+
+    Attributes:
+        name (str): The name of the node, inherited from the `Startable` base class.
+        conveyor (Conveyor): The `Conveyor` object responsible for carrying out the node's operation.
+        _kwargs (dict): A dictionary of keyword arguments used when calling the `Conveyor`.
+
+    Methods:
+        start() -> Tuple[bytes, bytes]:
+            Executes the `Conveyor` with the provided arguments, returning the result as a tuple of bytes.
+    """
+
     def __init__(self, name: str, conveyor: Conveyor, **kwargs):
+        """
+        Initializes a Node object with a name and a Conveyor.
+
+        Args:
+            name (str): The name of the node.
+            conveyor (Conveyor): The `Conveyor` object that will perform the operation associated with this node.
+            **kwargs: Additional keyword arguments to be passed to the `Conveyor` when called.
+        """
         super().__init__(name)
         self.conveyor = conveyor
 
@@ -13,4 +38,13 @@ class Node(Startable):
         self._kwargs = kwargs
 
     def start(self) -> Tuple[bytes, bytes]:
+        """
+        Starts the operation associated with the Node by invoking the Conveyor.
+
+        This method calls the `Conveyor` object with the stored keyword arguments and returns a tuple of bytes
+        representing the result of the operation.
+
+        Returns:
+            Tuple[bytes, bytes]: A tuple containing two byte sequences as the result of the Conveyor operation.
+        """
         return self.conveyor(**self._kwargs)

--- a/src/marsh/dag/node.py
+++ b/src/marsh/dag/node.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+
+from ..core import Conveyor
+from .startable import Startable
+
+
+class Node(Startable):
+    def __init__(self, name: str, conveyor: Conveyor, **kwargs):
+        super().__init__(name)
+        self.conveyor = conveyor
+
+        # Conveyor keyword arguments for __call__
+        self._kwargs = kwargs
+
+    def start(self) -> Tuple[bytes, bytes]:
+        return self.conveyor(**self._kwargs)

--- a/src/marsh/dag/startable.py
+++ b/src/marsh/dag/startable.py
@@ -3,9 +3,46 @@ from typing import Optional, Any
 
 
 class Startable(ABC):
+    """
+    Abstract base class for objects that can be started, such as nodes or DAGs.
+
+    This class defines a common interface for objects that need to be started.
+    Subclasses like `Node` and `Dag` will implement the `start` method with their own logic,
+    while inheriting from `Startable` to ensure they follow the expected contract for starting.
+
+    Attributes:
+        name (str): A hashable name that identifies the object within a node or directed acyclic graph (DAG).
+            This will be used to define the graph in `graphlib.TopologicalSorter`.
+
+    Methods:
+        start(*args, **kwargs):
+            Starts the object with optional arguments. Subclasses must implement this method with their own logic,
+            defining how the object is started. It may return any type or `None`.
+    """
+
     def __init__(self, name: str):
+        """
+        Initializes a Startable object with a given name.
+
+        Args:
+            name (str): A hashable name for the node or DAG.
+                This name is used to identify and reference the object.
+        """
         self.name = name  # Hashable name for Node and Dag
 
     @abstractmethod
     def start(self, *args, **kwargs) -> Optional[Any]:
+        """
+        Abstract method that starts the object.
+
+        This method must be implemented by subclasses such as `Node` or `Dag` to define the specific behavior
+        for starting the object. It should handle the logic for initiating the object's state or execution.
+
+        Args:
+            *args: Positional arguments passed to the method.
+            **kwargs: Keyword arguments passed to the method.
+
+        Returns:
+            Optional[Any]: The result of the start operation, which may be of any type, or `None`.
+        """
         pass

--- a/src/marsh/dag/startable.py
+++ b/src/marsh/dag/startable.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Any
+
+
+class Startable(ABC):
+    def __init__(self, name: str):
+        self.name = name  # Hashable name for Node and Dag
+
+    @abstractmethod
+    def start(self, *args, **kwargs) -> Optional[Any]:
+        pass

--- a/tests/dag/test_dag_base.py
+++ b/tests/dag/test_dag_base.py
@@ -1,0 +1,104 @@
+import pytest
+
+from marsh import Conveyor
+from marsh.dag import Dag, Node
+
+
+class MockConveyor(Conveyor):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, *args, **kwargs):
+        return b"stdout", b"stderr"
+
+
+@pytest.fixture
+def setup_dag():
+    return Dag("test_dag")
+
+
+def test_dag_initialization(setup_dag):
+    dag = setup_dag
+    assert dag.name == "test_dag"
+    assert dag.startables == []
+    assert dag.graph == {}
+
+
+def test_dag_add_node(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node = Node("A", conveyor)
+    dag.add(node)
+    assert dag.startables == [node]
+    assert dag.graph == {"A": set()}
+
+
+def test_dag_add_node_with_dependencies(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node_a = Node("A", conveyor)
+    node_b = Node("B", conveyor)
+    dag.add(node_b, node_a)
+    assert dag.startables == [node_b, node_a]
+    assert dag.graph == {"A": set(), "B": {"A"}}
+
+
+def test_dag_remove_node(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node = Node("A", conveyor)
+    dag.add(node)
+    dag.remove(node)
+    assert dag.startables == []
+    assert dag.graph == {}
+
+
+def test_dag_then_chaining(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node_a = Node("A", conveyor)
+    node_b = Node("B", conveyor)
+    dag.do(node_a).then(node_b)
+    assert dag.startables == [node_a, node_b]
+    assert dag.graph == {"A": set(), "B": {"A"}}
+
+
+def test_dag_when_dependency(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node_a = Node("A", conveyor)
+    node_b = Node("B", conveyor)
+    dag.do(node_a).when(node_b)
+    assert dag.startables == [node_a, node_b]
+    assert dag.graph == {"A": {"B"}, "B": set()}
+
+
+def test_dag_then_and_when_chaining(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node_a = Node("A", conveyor)
+    node_b = Node("B", conveyor)
+    node_c = Node("C", conveyor)
+    dag.do(node_a).then(node_b).when(node_c)
+    assert dag.startables == [node_a, node_b, node_c]
+    assert dag.graph == {"B": {"A", "C"}, "C": set(), "A": set()}
+
+
+def test_dag_reset(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node = Node("A", conveyor)
+    dag.add(node)
+    dag.reset()
+    assert dag.startables == []
+    assert dag.graph == {}
+
+
+def test_dag_sorted_names(setup_dag):
+    dag = setup_dag
+    conveyor = MockConveyor()
+    node_a = Node("A", conveyor)
+    node_b = Node("B", conveyor)
+    node_c = Node("C", conveyor)
+    dag.add(node_a).then(node_b).then(node_c)
+    assert dag.sorted_names == ["A", "B", "C"]

--- a/tests/dag/test_dags.py
+++ b/tests/dag/test_dags.py
@@ -1,0 +1,166 @@
+from graphlib import TopologicalSorter, CycleError
+
+import pytest
+
+from marsh import Conveyor
+from marsh.dag import (
+    Node,
+    Dag,
+    SyncDag,
+    AsyncDag,
+    ThreadPoolDag,
+    ThreadDag,
+    MultiprocessDag,
+    ProcessPoolDag
+)
+
+
+def mock_cmd_runner(x_stdout: bytes, x_stderr: bytes, name: str):
+    return f"{name}-stdout".encode(), f"{name}-stderr".encode()
+
+
+@pytest.fixture
+def setup_nodes():
+    def _create_node(name: str) -> Node:
+        return Node(name, Conveyor().add_cmd_runner(mock_cmd_runner, name))
+
+    return {
+        letter.upper(): _create_node(letter.upper())
+        for letter in ["a", "b", "c", "d", "e", "f", "g"]
+    }
+
+
+@pytest.fixture(params=[SyncDag, AsyncDag, ThreadPoolDag, ThreadDag, MultiprocessDag, ProcessPoolDag])
+def setup_dag_kind(request):
+    return request.param
+
+
+@pytest.fixture
+def setup_dag(setup_dag_kind, setup_nodes):
+    dag_kind = setup_dag_kind
+    nodes: dict[str, Node] = setup_nodes
+
+    # Instantiate the Dag with their default constructor parameters and give name
+    dag = dag_kind(f"Mock-{dag_kind.__name__}")
+
+    # Define the node dependencies
+    dag.do(nodes["A"]).then(nodes["C"], nodes["D"], nodes["F"], nodes["G"])
+    dag.do(nodes["B"]).then(nodes["D"], nodes["E"])
+    dag.do(nodes["C"]).then(nodes["G"])
+    dag.do(nodes["D"]).then(nodes["F"])
+    dag.do(nodes["E"]).then(nodes["G"])
+
+    return dag
+
+
+@pytest.fixture
+def setup_expected_results():
+    return {
+        "A": (b"A-stdout", b"A-stderr"),
+        "B": (b"B-stdout", b"B-stderr"),
+        "C": (b"C-stdout", b"C-stderr"),
+        "D": (b"D-stdout", b"D-stderr"),
+        "E": (b"E-stdout", b"E-stderr"),
+        "F": (b"F-stdout", b"F-stderr"),
+        "G": (b"G-stdout", b"G-stderr"),
+    }
+
+
+def test_dag_graph(setup_dag):
+    """Test Dependency Correctness."""
+    dag = setup_dag
+    assert dag.graph == {
+        "A": set(),
+        "B": set(),
+        "C": {"A"},
+        "D": {"A", "B"},
+        "E": {"B"},
+        "F": {"A", "D"},
+        "G": {"A", "C", "E"}
+    }
+
+
+def test_dag_properties(setup_dag):
+    """Test Dag Property Value Correctness."""
+    dag = setup_dag
+    assert set(dag.names) == {"A", "B", "C", "D", "E", "F", "G"}
+    assert len(dag.names) == 7
+    assert dag.sorted_names == ["A", "B", "C", "D", "E", "F", "G"]
+
+    for startable in dag.startables:
+        assert isinstance(startable, Node)
+
+    assert isinstance(dag.sorter, TopologicalSorter)
+
+
+def test_dag_results(setup_dag, setup_expected_results):
+    """Test Consistency in Results."""
+    dag = setup_dag
+    expected_results = setup_expected_results
+    results = dag.start()
+
+    assert len(results) == len(expected_results)
+    assert results == expected_results
+
+
+# ======================================================================================================================
+
+
+def test_dag_when_1_startable(setup_dag_kind, setup_nodes):
+    dag_kind = setup_dag_kind
+    node_dict = setup_nodes
+
+    dag = dag_kind(f"Mock-{dag_kind.__name__}")
+    dag.add(node_dict["A"])
+    results = dag.start()
+
+    assert results == {"A": (b"A-stdout", b"A-stderr")}
+
+
+def test_dag_when_2_startables_with_dependency(setup_dag_kind, setup_nodes):
+    dag_kind = setup_dag_kind
+    node_dict = setup_nodes
+
+    dag = dag_kind(f"Mock-{dag_kind.__name__}")
+    dag.do(node_dict["A"]).then(node_dict["B"])  # A --> B
+    results = dag.start()
+
+    expected_results = {
+        "A": (b"A-stdout", b"A-stderr"),
+        "B": (b"B-stdout", b"B-stderr")
+    }
+
+    assert results == expected_results
+
+
+def test_dag_when_2_startables_without_dependency(setup_dag_kind, setup_nodes):
+    dag_kind = setup_dag_kind
+    node_dict = setup_nodes
+
+    dag = dag_kind(f"Mock-{dag_kind.__name__}")
+    dag.add(node_dict["A"])
+    dag.add(node_dict["B"])
+    results = dag.start()
+
+    expected_results = {
+        "A": (b"A-stdout", b"A-stderr"),
+        "B": (b"B-stdout", b"B-stderr")
+    }
+
+    assert results == expected_results
+
+
+def test_dag_when_cycle_exist(setup_dag_kind, setup_nodes):
+    dag_kind = setup_dag_kind
+    node_dict = setup_nodes
+
+    dag = dag_kind(f"Mock-{dag_kind.__name__}")
+    dag.do(node_dict["A"]).then(node_dict["B"])
+    dag.do(node_dict["B"]).then(node_dict["C"])
+    dag.do(node_dict["C"]).then(node_dict["A"])
+    # A -> B
+    # B -> C
+    # C -> A  // Cycle
+
+    with pytest.raises(CycleError):
+        results = dag.start()

--- a/tests/dag/test_node.py
+++ b/tests/dag/test_node.py
@@ -1,0 +1,63 @@
+import pytest
+
+from marsh import Conveyor
+from marsh.dag import Node
+
+
+def mock_cmd_runner(stdout: bytes, stderr: bytes) -> tuple[bytes, bytes]:
+    return stdout + b"_cmd_executed", stderr
+
+
+def test_node_initialization():
+    conveyor = Conveyor()
+    node = Node(name="test_node", conveyor=conveyor)
+
+    assert node.name == "test_node"
+    assert node.conveyor is conveyor
+
+
+def test_node_start_single_command():
+    conveyor = Conveyor().add_cmd_runner(mock_cmd_runner)
+    node = Node(name="test_node", conveyor=conveyor)
+    stdout, stderr = node.start()
+
+    assert stdout == b"_cmd_executed"
+    assert stderr == b""
+
+
+def test_node_start_multiple_commands():
+    def cmd_runner_2(stdout: bytes, stderr: bytes) -> tuple[bytes, bytes]:
+        return stdout + b"_second_cmd", stderr
+
+    conveyor = Conveyor().add_cmd_runner(mock_cmd_runner).add_cmd_runner(cmd_runner_2)
+    node = Node(name="test_node", conveyor=conveyor)
+    stdout, stderr = node.start()
+
+    assert stdout == b"_cmd_executed_second_cmd"
+    assert stderr == b""
+
+
+def test_node_with_kwargs():
+    def cmd_with_kwargs(stdout: bytes, stderr: bytes, suffix: bytes) -> tuple[bytes, bytes]:
+        return stdout + suffix, stderr
+
+    conveyor = Conveyor().add_cmd_runner(cmd_with_kwargs, suffix=b"_kwarg_test")
+    node = Node(name="test_node", conveyor=conveyor)
+    stdout, stderr = node.start()
+
+    assert stdout == b"_kwarg_test"
+    assert stderr == b""
+
+
+def test_node_empty_conveyor():
+    conveyor = Conveyor()
+    node = Node(name="test_node", conveyor=conveyor)
+    stdout, stderr = node.start()
+
+    assert stdout == b""
+    assert stderr == b""
+
+
+def test_node_invalid_cmd_runner():
+    with pytest.raises(TypeError):
+        Conveyor().add_cmd_runner("not_a_callable")

--- a/tests/dag/test_startable.py
+++ b/tests/dag/test_startable.py
@@ -1,0 +1,11 @@
+from marsh.dag import Startable
+
+
+def test_startable_abstract():
+    class TestStartable(Startable):
+        def start(self):
+            return "Test started"
+
+    startable = TestStartable("test")
+    assert startable.name == "test"
+    assert startable.start() == "Test started"


### PR DESCRIPTION
## Description
Subpackage for extending Marsh for non-linear command dependency using DAG data structure and the built-in `graphlib` module.

### Components:

- `Startable` - Abstract base class for **_startable_** objects (Node and Dag).
- `Node` - Entity that encapsulates **Conveyor** and run it.
- `Dag` - Base Class for defining startable (which can be other _Dag_'s) dependencies and running the workflow. The `start` method must be overridden.

### Dag kinds:

- `SyncDag`
- `AsyncDag`
- `ThreadPoolDag`
- `ThreadDag`
- `MultiprocessDag`
- `ProcessPoolDag`

### Notes:
- There are no ***result passing*** (i.e. if a startable depends on another startable, the dependent startable cannot reference the results of their dependencies). It's all about dependency definition and the order of running them. 
- The `Dag.start()` method returns `Dict[str, Tuple[bytes, bytes] | dict]` where the key represents the name of the startable, and the value `Tuple[bytes, bytes]` is the result when the startable is a Node (with the Conveyor), or `dict` when the startable is another Dag.

## What kind of changes did you make?
- [X] Add new feature or enhancement (core or non-core components)?
- [X] Add or update extensions (non-core components)?
- [ ] Refactor or optimize code?
- [ ] Fix a bug?
- [X] Add or update the documentations?
- [X] Add or update the tests?

## Checklist
- [X] This PR represents my original work and does not include plagiarized code.
- [X] I have read and adhered to the project’s CONTRIBUTING guidelines.
- [X] I have followed the project's coding style and guidelines.
- [X] Documentation has been updated to reflect changes (e.g., README, inline comments, etc.).
- [X] Related API documentation, if any, has been updated.
- [X] My code is self-documented with clear comments for complex areas.
- [X] Public methods and classes include appropriate docstrings.
- [X] Function names, variables, and class names are descriptive and adhere to naming conventions.
- [X] I understand that pull requests will not be merged if they do not pass the automated tests.
- [X] New functionality is covered by automated tests.
- [X] Code changes have been tested across relevant environments or configurations.
- [X] I have verified that the changes do not introduce any new vulnerabilities or security risks.
